### PR TITLE
v0.2.0 작업 내역 PR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.5'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.5'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.mc'
@@ -9,32 +9,34 @@ version = '0.0.1-SNAPSHOT'
 description = 'mental care application poc'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'com.openai:openai-java:3.6.0'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: local
       JAVA_TOOL_OPTIONS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
       # 필요 시 주석 해제해서 사용
       # OPENAI_API_KEY: your-key-here
       # SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_GOOGLE_CLIENT_ID: ""

--- a/src/main/java/com/mc/backend/ai/ChatController.java
+++ b/src/main/java/com/mc/backend/ai/ChatController.java
@@ -1,0 +1,23 @@
+package com.mc.backend.ai;
+
+
+import com.mc.backend.ai.dto.ChatRequest;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/chat")
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final SafetyRouterService router;
+
+    @PostMapping("/messages")
+    public Map<String, Object> send(@RequestBody ChatRequest req) {
+        return router.chatOnce(req.message());
+    }
+}

--- a/src/main/java/com/mc/backend/ai/OpenAiGateway.java
+++ b/src/main/java/com/mc/backend/ai/OpenAiGateway.java
@@ -1,0 +1,119 @@
+package com.mc.backend.ai;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mc.backend.ai.dto.ModerationRequest;
+import com.mc.backend.ai.dto.ModerationResponse;
+import com.mc.backend.ai.dto.ResponseFormat;
+import com.mc.backend.ai.dto.ResponsesEnvelope;
+import com.mc.backend.ai.dto.ResponsesRequest;
+import com.mc.backend.ai.dto.RiskOnlySchema;
+import com.mc.backend.ai.dto.RiskOnlyVerdict;
+import com.mc.backend.ai.dto.RiskReply;
+import com.mc.backend.ai.dto.RiskReplySchema;
+import com.mc.backend.config.ExternalWebClientFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@Slf4j
+public class OpenAiGateway {
+
+    private final WebClient client;
+    private final ObjectMapper om;
+    private final String primaryModel;
+    private final String escalationModel;
+
+    public OpenAiGateway(
+        ExternalWebClientFactory factory,
+        ObjectMapper om,
+        @Value("${openai.primary-model}") String primaryModel,
+        @Value("${openai.escalation-model}") String escalationModel
+    ) {
+        this.client = factory.get("openai");
+        this.om = om;
+        this.primaryModel = primaryModel;
+        this.escalationModel = escalationModel;
+    }
+
+    // Moderation
+    public ModerationResponse moderate(String text) {
+        var req = new ModerationRequest("omni-moderation-latest", text);
+        try {
+            return client.post().uri("/moderations")
+                .bodyValue(req)
+                .retrieve()
+                .bodyToMono(ModerationResponse.class)
+                .block();
+        } catch (Exception e) {
+            // 폴백: 실패 시 flagged=false 취급
+            return new ModerationResponse(
+                java.util.List.of(new ModerationResponse.Result(false, null)));
+        }
+    }
+
+    // mini: 구조화 응답
+    public RiskReply classifyWithMini(String systemPrompt, String userText) {
+        String input = systemPrompt + "\n\n사용자: " + userText;
+
+        var schema = new RiskReplySchema();
+        var req = ResponsesRequest.of(
+            primaryModel,
+            input,
+            ResponseFormat.jsonSchema("RiskReply", schema, true),
+            400
+        );
+
+        ResponsesEnvelope env = client.post().uri("/responses")
+            .bodyValue(req)
+            .retrieve()
+            .bodyToMono(ResponsesEnvelope.class)
+            .block();
+
+        String json = env != null ? env.firstText() : null;
+        if (json == null || json.isBlank()) {
+            return new RiskReply("지금은 답변을 준비할 수 없어요. 잠시 후 다시 시도해 주세요.",
+                null, com.mc.backend.ai.enums.RiskLevel.WATCH, 0.5);
+        }
+        try {
+            return om.readValue(json, RiskReply.class);
+        } catch (Exception ex) {
+            return new RiskReply("잠시 후 다시 시도해 주세요.",
+                null, com.mc.backend.ai.enums.RiskLevel.WATCH, 0.5);
+        }
+    }
+
+    // GPT-5: 리스크만 2차 판정
+    public RiskOnlyVerdict verdictWithGpt5(String userText) {
+        String sys = """
+            당신은 안전 판정 어시스턴트입니다.
+            입력 텍스트의 위험도를 'ok|watch|concern|crisis' 중 하나로 평가하고
+            confidence(0~1)를 제공합니다. 출력은 JSON 스키마만 허용합니다.
+            """;
+
+        var schema = new RiskOnlySchema();
+        var req = ResponsesRequest.of(
+            escalationModel,
+            sys + "\n\n텍스트: " + userText,
+            ResponseFormat.jsonSchema("RiskOnly", schema, true),
+            120
+        );
+
+        ResponsesEnvelope env = client.post().uri("/responses")
+            .bodyValue(req)
+            .retrieve()
+            .bodyToMono(ResponsesEnvelope.class)
+            .block();
+
+        String json = env != null ? env.firstText() : null;
+        if (json == null) {
+            return new RiskOnlyVerdict(com.mc.backend.ai.enums.RiskLevel.WATCH, 0.5);
+        }
+        try {
+            return om.readValue(json, RiskOnlyVerdict.class);
+        } catch (Exception e) {
+            return new RiskOnlyVerdict(com.mc.backend.ai.enums.RiskLevel.WATCH, 0.5);
+        }
+    }
+}

--- a/src/main/java/com/mc/backend/ai/SafetyRouterService.java
+++ b/src/main/java/com/mc/backend/ai/SafetyRouterService.java
@@ -1,0 +1,86 @@
+package com.mc.backend.ai;
+
+import com.mc.backend.ai.dto.ModerationResponse;
+import com.mc.backend.ai.dto.RiskOnlyVerdict;
+import com.mc.backend.ai.dto.RiskReply;
+import com.mc.backend.ai.enums.RiskLevel;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SafetyRouterService {
+
+    private final OpenAiGateway openai;
+    private final double CONF_T;
+
+    public SafetyRouterService(OpenAiGateway openai,
+        @Value("${openai.safety.confidence-threshold:0.6}") double confT) {
+        this.openai = openai;
+        this.CONF_T = confT;
+    }
+
+    private static final String SYSTEM_PROMPT = """
+        당신은 공감적이고 비판단적인 멘탈헬스 보조 챗봇입니다.
+        - 의료적 진단/치료 약속은 하지 않습니다.
+        - 위기 신호가 강하면 즉시 '도움 안내'를 권유합니다.
+        - 한국어로 3~6문장, 따뜻하고 간결하게 답하세요.
+        - 출력은 JSON 스키마(reply/next_question/risk_level/confidence)에 맞춰야 합니다.
+        """;
+
+    private boolean moderationHighRisk(ModerationResponse m) {
+        if (m == null || m.results() == null || m.results().isEmpty()) {
+            return false;
+        }
+        var r = m.results().get(0);
+        if (r.flagged()) {
+            return true;
+        }
+        var cats = r.categories();
+        return cats != null && cats.isSelfHarm();
+    }
+
+    public Map<String, Object> chatOnce(String userText) {
+        // 0) Pre-moderation
+        if (moderationHighRisk(openai.moderate(userText))) {
+            return crisisTemplate();
+        }
+
+        // 1) mini
+        RiskReply rr = openai.classifyWithMini(SYSTEM_PROMPT, userText);
+
+        boolean escalate =
+            (rr.riskLevel() == RiskLevel.CONCERN || rr.riskLevel() == RiskLevel.CRISIS)
+                && (rr.confidence() != null && rr.confidence() >= CONF_T);
+
+        if (escalate) {
+            RiskOnlyVerdict v = openai.verdictWithGpt5(userText);
+            if (v.riskLevel() == RiskLevel.CONCERN || v.riskLevel() == RiskLevel.CRISIS) {
+                return crisisTemplate();
+            }
+        }
+
+        // 2) Post-moderation(출력)
+        if (moderationHighRisk(openai.moderate(rr.reply()))) {
+            return crisisTemplate();
+        }
+
+        return Map.of(
+            "reply", rr.reply(),
+            "next_question", rr.nextQuestion(),
+            "risk_level", rr.riskLevel(), // Enum → JSON은 소문자로 직렬화
+            "confidence", rr.confidence()
+        );
+    }
+
+    private Map<String, Object> crisisTemplate() {
+        String msg = "지금 많이 힘드신 것 같아요. 혼자가 아니에요. " +
+            "긴급한 위험이 느껴지면 112/119에 바로 연락하시고, " +
+            "상담이 필요하면 1393(자살 예방 상담)으로 도움을 받아보실 수 있어요.";
+        return Map.of(
+            "reply", msg,
+            "risk_level", RiskLevel.CRISIS,
+            "confidence", 0.9
+        );
+    }
+}

--- a/src/main/java/com/mc/backend/ai/dto/ChatRequest.java
+++ b/src/main/java/com/mc/backend/ai/dto/ChatRequest.java
@@ -1,0 +1,7 @@
+package com.mc.backend.ai.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ChatRequest(@NotBlank String message) {
+    
+}

--- a/src/main/java/com/mc/backend/ai/dto/JsonSchema.java
+++ b/src/main/java/com/mc/backend/ai/dto/JsonSchema.java
@@ -1,0 +1,11 @@
+package com.mc.backend.ai.dto;
+
+public record JsonSchema(String name, SchemaRoot schema, Boolean strict) {
+
+    /**
+     * 스키마 루트 타입(구체 스키마 클래스들이 구현)
+     */
+    public interface SchemaRoot {
+
+    }
+}

--- a/src/main/java/com/mc/backend/ai/dto/ModerationCategories.java
+++ b/src/main/java/com/mc/backend/ai/dto/ModerationCategories.java
@@ -1,0 +1,22 @@
+package com.mc.backend.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 필요한 카테고리만 정의, 나머지는 무시
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ModerationCategories {
+
+    @JsonProperty("self-harm")
+    private boolean selfHarm;
+    @JsonProperty("self-harm/intent")
+    private boolean selfHarmIntent;
+    @JsonProperty("self-harm/instructions")
+    private boolean selfHarmInstructions;
+
+    public boolean isSelfHarm() {
+        return selfHarm || selfHarmIntent || selfHarmInstructions;
+    }
+}

--- a/src/main/java/com/mc/backend/ai/dto/ModerationRequest.java
+++ b/src/main/java/com/mc/backend/ai/dto/ModerationRequest.java
@@ -1,0 +1,5 @@
+package com.mc.backend.ai.dto;
+
+public record ModerationRequest(String model, String input) {
+
+}

--- a/src/main/java/com/mc/backend/ai/dto/ModerationResponse.java
+++ b/src/main/java/com/mc/backend/ai/dto/ModerationResponse.java
@@ -1,0 +1,10 @@
+package com.mc.backend.ai.dto;
+
+import java.util.List;
+
+public record ModerationResponse(List<Result> results) {
+
+    public record Result(boolean flagged, ModerationCategories categories) {
+
+    }
+}

--- a/src/main/java/com/mc/backend/ai/dto/ResponseFormat.java
+++ b/src/main/java/com/mc/backend/ai/dto/ResponseFormat.java
@@ -1,0 +1,15 @@
+package com.mc.backend.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ResponseFormat(String type, String name, Boolean strict,
+                             JsonSchema.SchemaRoot schema) {
+
+    public static ResponseFormat jsonSchema(String name, JsonSchema.SchemaRoot schema,
+        boolean strict) {
+        return new ResponseFormat("json_schema", name, strict, schema);
+    }
+
+
+}

--- a/src/main/java/com/mc/backend/ai/dto/ResponsesEnvelope.java
+++ b/src/main/java/com/mc/backend/ai/dto/ResponsesEnvelope.java
@@ -1,0 +1,25 @@
+package com.mc.backend.ai.dto;
+
+import java.util.List;
+
+public record ResponsesEnvelope(List<Output> output) {
+
+    public String firstText() {
+        if (output == null || output.isEmpty()) {
+            return null;
+        }
+        var cont = output.get(0).content();
+        if (cont == null || cont.isEmpty()) {
+            return null;
+        }
+        return cont.get(0).text();
+    }
+
+    public record Output(String id, String type, String role, List<Content> content) {
+
+    }
+
+    public record Content(String type, String text) {
+
+    }
+}

--- a/src/main/java/com/mc/backend/ai/dto/ResponsesRequest.java
+++ b/src/main/java/com/mc/backend/ai/dto/ResponsesRequest.java
@@ -1,0 +1,14 @@
+package com.mc.backend.ai.dto;
+
+public record ResponsesRequest(
+    String model,
+    Object input,
+    TextOptions text,
+    Integer max_output_tokens
+) {
+
+    public static ResponsesRequest of(String model, Object input, ResponseFormat fmt,
+        int maxTokens) {
+        return new ResponsesRequest(model, input, new TextOptions(fmt), maxTokens);
+    }
+}

--- a/src/main/java/com/mc/backend/ai/dto/RiskOnlySchema.java
+++ b/src/main/java/com/mc/backend/ai/dto/RiskOnlySchema.java
@@ -1,0 +1,59 @@
+package com.mc.backend.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RiskOnlySchema implements JsonSchema.SchemaRoot {
+
+    private final String type = "object";
+    private final Properties properties = new Properties();
+    private final String[] required = new String[]{"risk_level", "confidence"};
+    @JsonProperty("additionalProperties")
+    private final boolean additionalProperties = false;
+
+    public String getType() {
+        return type;
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+
+    public String[] getRequired() {
+        return required;
+    }
+
+    public boolean isAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    public static class Properties {
+
+        @JsonProperty("risk_level")
+        public final EnumString risk_level = new EnumString(
+            new String[]{"ok", "watch", "concern", "crisis"});
+        public final NumberRange confidence = new NumberRange(0.0, 1.0);
+    }
+
+    public static class NumberRange {
+
+        public final String type = "number";
+        public final Double minimum;
+        public final Double maximum;
+
+        public NumberRange(Double min, Double max) {
+            this.minimum = min;
+            this.maximum = max;
+        }
+    }
+
+    public static class EnumString {
+
+        public final String type = "string";
+        @JsonProperty("enum")
+        public final String[] values;
+
+        public EnumString(String[] values) {
+            this.values = values;
+        }
+    }
+}

--- a/src/main/java/com/mc/backend/ai/dto/RiskOnlyVerdict.java
+++ b/src/main/java/com/mc/backend/ai/dto/RiskOnlyVerdict.java
@@ -1,0 +1,11 @@
+package com.mc.backend.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mc.backend.ai.enums.RiskLevel;
+
+public record RiskOnlyVerdict(
+    @JsonProperty("risk_level") RiskLevel riskLevel,
+    Double confidence
+) {
+
+}

--- a/src/main/java/com/mc/backend/ai/dto/RiskReply.java
+++ b/src/main/java/com/mc/backend/ai/dto/RiskReply.java
@@ -1,0 +1,14 @@
+package com.mc.backend.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mc.backend.ai.enums.RiskLevel;
+
+// 우리가 원하는 구조화 결과(JSON → 매핑)
+public record RiskReply(
+    String reply,
+    @JsonProperty("next_question") String nextQuestion,
+    @JsonProperty("risk_level") RiskLevel riskLevel,
+    Double confidence
+) {
+
+}

--- a/src/main/java/com/mc/backend/ai/dto/RiskReplySchema.java
+++ b/src/main/java/com/mc/backend/ai/dto/RiskReplySchema.java
@@ -1,0 +1,68 @@
+package com.mc.backend.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RiskReplySchema implements JsonSchema.SchemaRoot {
+
+    private final String type = "object";
+    private final Properties properties = new Properties();
+    private final String[] required = new String[]{"reply", "risk_level", "confidence",
+        "next_question"};
+    @JsonProperty("additionalProperties")
+    private final boolean additionalProperties = false;
+
+    public String getType() {
+        return type;
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+
+    public String[] getRequired() {
+        return required;
+    }
+
+    public boolean isAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    public static class Properties {
+
+        public final StringType reply = new StringType();
+        @JsonProperty("next_question")
+        public final StringType next_question = new StringType();
+        @JsonProperty("risk_level")
+        public final EnumString risk_level = new EnumString(
+            new String[]{"ok", "watch", "concern", "crisis"});
+        public final NumberRange confidence = new NumberRange(0.0, 1.0);
+    }
+
+    public static class StringType {
+
+        public final String type = "string";
+    }
+
+    public static class NumberRange {
+
+        public final String type = "number";
+        public final Double minimum;
+        public final Double maximum;
+
+        public NumberRange(Double min, Double max) {
+            this.minimum = min;
+            this.maximum = max;
+        }
+    }
+
+    public static class EnumString {
+
+        public final String type = "string";
+        @JsonProperty("enum")
+        public final String[] values;
+
+        public EnumString(String[] values) {
+            this.values = values;
+        }
+    }
+}

--- a/src/main/java/com/mc/backend/ai/dto/TextOptions.java
+++ b/src/main/java/com/mc/backend/ai/dto/TextOptions.java
@@ -1,0 +1,5 @@
+package com.mc.backend.ai.dto;
+
+public record TextOptions(ResponseFormat format) {
+
+}

--- a/src/main/java/com/mc/backend/ai/enums/RiskLevel.java
+++ b/src/main/java/com/mc/backend/ai/enums/RiskLevel.java
@@ -1,0 +1,18 @@
+package com.mc.backend.ai.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum RiskLevel {
+    OK, WATCH, CONCERN, CRISIS;
+
+    @JsonValue
+    public String toJson() {
+        return name().toLowerCase();
+    }
+
+    @JsonCreator
+    public static RiskLevel fromJson(String v) {
+        return v == null ? WATCH : RiskLevel.valueOf(v.trim().toUpperCase());
+    }
+}

--- a/src/main/java/com/mc/backend/config/ExternalApisProperties.java
+++ b/src/main/java/com/mc/backend/config/ExternalApisProperties.java
@@ -1,0 +1,58 @@
+package com.mc.backend.config;
+
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "external.apis")
+public class ExternalApisProperties {
+
+    private Map<String, Api> clients;
+
+    public Map<String, Api> getClients() {
+        return clients;
+    }
+
+    public void setClients(Map<String, Api> clients) {
+        this.clients = clients;
+    }
+
+    public static class Api {
+
+        private String baseUrl;
+        private String apiKey; // 있을 수도/없을 수도
+        private Integer timeoutMs;
+        private Map<String, String> headers;
+
+        public String getBaseUrl() {
+            return baseUrl;
+        }
+
+        public void setBaseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+        }
+
+        public String getApiKey() {
+            return apiKey;
+        }
+
+        public void setApiKey(String apiKey) {
+            this.apiKey = apiKey;
+        }
+
+        public Integer getTimeoutMs() {
+            return timeoutMs;
+        }
+
+        public void setTimeoutMs(Integer timeoutMs) {
+            this.timeoutMs = timeoutMs;
+        }
+
+        public Map<String, String> getHeaders() {
+            return headers;
+        }
+
+        public void setHeaders(Map<String, String> headers) {
+            this.headers = headers;
+        }
+    }
+}

--- a/src/main/java/com/mc/backend/config/ExternalWebClientFactory.java
+++ b/src/main/java/com/mc/backend/config/ExternalWebClientFactory.java
@@ -1,0 +1,60 @@
+package com.mc.backend.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+@Component
+public class ExternalWebClientFactory {
+
+    private final WebClient.Builder baseBuilder;
+    private final ExternalApisProperties props;
+    private final ConcurrentMap<String, WebClient> cache = new ConcurrentHashMap<>();
+
+    public ExternalWebClientFactory(WebClient.Builder baseBuilder, ExternalApisProperties props) {
+        this.baseBuilder = baseBuilder;
+        this.props = props;
+    }
+
+    public WebClient get(String name) {
+        return cache.computeIfAbsent(name, this::buildClient);
+    }
+
+    private WebClient buildClient(String name) {
+        ExternalApisProperties.Api cfg = Objects.requireNonNull(props.getClients().get(name),
+            "Unknown external api client: " + name);
+
+        // 클라이언트별 타임아웃(있으면 덮어쓰기)
+        WebClient.Builder b = baseBuilder.clone()
+            .baseUrl(cfg.getBaseUrl());
+
+        // per-client timeout 적용
+        Integer t = cfg.getTimeoutMs();
+        if (t != null && t > 0) {
+            HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, t)
+                .responseTimeout(Duration.ofMillis(t))
+                .doOnConnected(conn -> conn.addHandlerLast(
+                    new ReadTimeoutHandler(t, java.util.concurrent.TimeUnit.MILLISECONDS)));
+            b.clientConnector(new ReactorClientHttpConnector(httpClient));
+        }
+
+        // 헤더
+        if (cfg.getHeaders() != null) {
+            cfg.getHeaders().forEach(b::defaultHeader);
+        }
+        // API 키 → Authorization Bearer 자동 주입(있을 때만)
+        if (cfg.getApiKey() != null && !cfg.getApiKey().isBlank()) {
+            b.defaultHeader("Authorization", "Bearer " + cfg.getApiKey());
+        }
+
+        return b.build();
+    }
+}

--- a/src/main/java/com/mc/backend/config/HttpClientConfig.java
+++ b/src/main/java/com/mc/backend/config/HttpClientConfig.java
@@ -1,0 +1,76 @@
+package com.mc.backend.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+@Configuration
+@Slf4j
+@EnableConfigurationProperties(ExternalApisProperties.class)
+public class HttpClientConfig {
+
+    @Bean
+    public WebClient.Builder baseWebClientBuilder(
+        @Value("${external.default-timeout-ms:15000}") int defaultTimeoutMs
+    ) {
+        HttpClient httpClient = HttpClient.create()
+//            .wiretap("reactor.netty.http.client.HttpClient",
+//                LogLevel.DEBUG, AdvancedByteBufFormat.TEXTUAL)
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, defaultTimeoutMs)
+            .responseTimeout(Duration.ofMillis(defaultTimeoutMs))
+            .doOnConnected(conn -> conn.addHandlerLast(
+                new ReadTimeoutHandler(defaultTimeoutMs, TimeUnit.MILLISECONDS)));
+
+        return WebClient.builder()
+            .clientConnector(new ReactorClientHttpConnector(httpClient))
+            .filter(logRequest())
+            .filter(logResponse());
+    }
+
+    private ExchangeFilterFunction logRequest() {
+        return ExchangeFilterFunction.ofRequestProcessor(req -> {
+            System.out.println("HTTP " + req.method() + " " + req.url());
+            log.info("========== WebClient HTTP LOG REQUEST INFO     ==========");
+            log.info("URL : {}", req.url());
+            log.info("METHOD : {}", req.method());
+            log.info("Content-Type : {}", req.headers().get("Content-Type"));
+            log.info("Authorization : {}", req.headers().get("Authorization"));
+//            log.info("BODY : {}", req.body().toString()) todo: 나중에 body 로그는 어떻게 할지 고민 필요
+            log.info("========== WebClient HTTP LOG REQUEST INFO END ==========");
+            return Mono.just(req);
+        });
+    }
+
+    private ExchangeFilterFunction logResponse() {
+        return ExchangeFilterFunction.ofResponseProcessor(res -> res
+            .bodyToMono(String.class)
+            .flatMap(body -> {
+                // 응답 로그
+                log.info("========== WebClient HTTP LOG RESPONSE INFO     ==========");
+                log.info("URL : {}", res.request().getURI());
+                log.info("METHOD : {}", res.request().getMethod());
+                log.info("STATUS : {}", res.statusCode());
+                log.info("BODY : {}", body);
+                log.info("========== WebClient HTTP LOG RESPONSE INFO END ==========");
+
+                // body를 다시 복원해서 내려주지 않으면 downstream에서 못 읽음
+                return Mono.just(
+                    ClientResponse.from(res)
+                        .body(body)  // String으로 다시 넣음
+                        .build()
+                );
+            }));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,22 @@ spring.application.name=backend
 server.port=20001
 management.endpoints.web.exposure.include=health,info
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false
+# OpenAI
+#openai.api-key=${OPENAI_API_KEY}
+#openai.base-url=https://api.openai.com/v1
+#openai.primary-model=gpt-4.1-mini
+#openai.escalation-model=gpt-5
+#openai.timeout-ms=60000
+# ?? ???(?? ??)
+# ?? APi ??
+## Open AI API
+### WebClient ?? ??
+external.apis.clients.openai.base-url=https://api.openai.com/v1
+external.apis.clients.openai.api-key=${OPENAI_API_KEY}
+external.apis.clients.openai.timeout-ms=15000
+external.apis.clients.openai.headers.Content-Type=application/json
+### Open Ai ?? ??
+openai.primary-model=gpt-4.1-mini
+openai.escalation-model=gpt-5
+openai.safety.confidence-threshold=0.6
+


### PR DESCRIPTION
- Shared OpenAPI 초안 정리: `/assessments/phq9`, `/chat/messages`
- Structured Output 구조 확정: `reply`, `next_question`, `risk_level`, `confidence` (all required)
- 외부 호출 WebClient 통일 + Factory 패턴 문서화
- DTO/Enum 강타입 원칙 문서화(Map 금지, Enum 분리)
- 트러블슈팅 추가: Moderation 403, `text.format` 파라미터 변경, required 누락 오류
- 문서 전략: 최소 문서 유지 / docs 구조를 backend·frontend로 분리
- Swagger 전환 계획 수립